### PR TITLE
fix: make sure getArticle use the token retrieved from logIn

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -8,52 +8,47 @@ const client = new bot({
   protocol: config.protocol,           // Wikipedia now enforces HTTPS
   server: config.server,  // host name of MediaWiki-powered site
   path: config.path,                  // path to api.php script
-  debug: true                 // is more verbose when set to true
+  debug: true,                 // is more verbose when set to true
+  username: config.username,
+  password: config.password
 });
 
-function handleResponse(err, data) {
-  // error handling
+client.logIn( function (err) {
   if (err) {
     console.error(err);
-  } else {
-    console.log(data);
+    return;
   }
-}
 
-client.logIn(config.username, config.password, handleResponse);
+  client.getArticle('Meeting_Minutes', function (err, MeetingMinutesContent) {
+    // error handling
+    if (err) {
+      console.error(err);
+    } else {
+      let {title, index} = regex.findLastTwStandUpTitle(MeetingMinutesContent);
+      title = title.replace(/ /g, '_');
 
-client.getArticle('Meeting_Minutes', function (err, MeetingMinutesContent) {
-  // error handling
-  if (err) {
-    console.error(err);
-  } else {
-    let {title, index} = regex.findLastTwStandUpTitle(MeetingMinutesContent);
-    title = title.replace(/ /g, '_');
+      client.getArticle(title, function (err, data) {
+        if (err) {
+          console.error(err);
+        } else {
+          const cleanedContent = regex.cleanDoneSection(data);
+          const todayTitle = utils.generateTodayTitle();
+          const updatedMeetingMinutesContent = regex.generateNewMeetingMinutes(MeetingMinutesContent, index, todayTitle)
+          client.edit('Meeting_Minutes', updatedMeetingMinutesContent, null, false, function (err, data) {
+            if (err) {
+              console.log(err);
+            } else {
+              client.edit(todayTitle.replace(/ /g, '_'), cleanedContent, null, false, function (err, data) {
+                if (err) {
+                  console.log(err);
+                } else {
 
-    client.getArticle(title, function (err, data) {
-      if (err) {
-        console.error(err);
-      } else {
-        const cleanedContent = regex.cleanDoneSection(data);
-        const todayTitle = utils.generateTodayTitle();
-        const updatedMeetingMinutesContent = regex.generateNewMeetingMinutes(MeetingMinutesContent, index, todayTitle)
-        client.edit('Meeting_Minutes', updatedMeetingMinutesContent, null, false, function (err, data) {
-          if (err) {
-            console.log(err);
-          } else {
-            client.edit(todayTitle.replace(/ /g, '_'), cleanedContent, null, false, function (err, data) {
-              if (err) {
-                console.log(err);
-              } else {
-
-              }
-            });
-          }
-        })
-      }
-    });
-  }
+                }
+              });
+            }
+          })
+        }
+      });
+    }
+  });
 });
-
-
-


### PR DESCRIPTION
it seems the token retrieved by `client.logIn()` can pass along only if the `client.getArticle('Meeting_Minutes', ...) inside of the `client.logIn()`.